### PR TITLE
Events support in the eth-abi

### DIFF
--- a/derive/src/items.rs
+++ b/derive/src/items.rs
@@ -1,4 +1,5 @@
 use {quote, syn, utils};
+use abi::eth::NamedSignature;
 
 pub struct Interface {
 	name: String,
@@ -7,9 +8,17 @@ pub struct Interface {
 	items: Vec<Item>,
 }
 
+pub struct Event {
+	pub name: syn::Ident,
+	pub method_sig: syn::MethodSig,
+	indexed: Vec<(syn::Pat, syn::Ty)>,
+	data: Vec<(syn::Pat, syn::Ty)>,
+	signature: NamedSignature,
+}
+
 pub enum Item {
 	Signature(syn::Ident, syn::MethodSig),
-	Event(syn::Ident, syn::MethodSig),
+	Event(Event),
 	Other(syn::TraitItem),
 }
 
@@ -66,8 +75,24 @@ impl Item {
 					syn::MetaItem::Word(ref ident) => ident.as_ref() == "event" ,
 					_ => false
 				}) {
-					Item::Event(ident, method_sig)
+					let (indexed, non_indexed) = utils::iter_signature(&method_sig)
+						.partition(|&(ref pat, _)| quote! { #pat }.to_string().starts_with("indexed_"));
+
+					let named_signature =  NamedSignature::new(
+						ident.to_string(),
+						utils::parse_rust_signature(&method_sig)
+					);
+					let event = Event {
+						name: ident,
+						indexed: indexed,
+						data: non_indexed,
+						signature: named_signature,
+						method_sig: method_sig,
+					};
+
+					Item::Event(event)
 				} else {
+
 					Item::Signature(ident, method_sig)
 				}
 			},
@@ -78,43 +103,39 @@ impl Item {
 	}
 }
 
-pub struct Event {
-	name: syn::Ident,
-	indexed: Vec<(syn::Pat, syn::Ty)>,
-	data: Vec<(syn::Pat, syn::Ty)>,
-}
-
 impl quote::ToTokens for Item {
 	fn to_tokens(&self, tokens: &mut quote::Tokens) {
 		match *self {
-			Item::Event(ref name, ref method_sig) => {
-
-				let event = Event {
-					name: name.clone(),
-					indexed: {
-						method_sig.decl.inputs.iter().filter_map(|a| {
-							match *a {
-								syn::FnArg::Captured(ref pat, ref ty) => {
-									let pat_str = quote!{ pat }.to_string();
-									if pat_str.starts_with("indexed_") {
-										Some((pat.clone(), ty.clone()))
-									} else {
-										None
-									}
-								},
-								_ => None,
-							}
-						}).collect()
-					},
-					data: Vec::new(),
-				};
-
+			Item::Event(ref event) => {
+				let method_sig = &event.method_sig;
+				let name = &event.name;
 				tokens.append_all(&[
 					utils::produce_signature(
 						name,
 						method_sig,
-						quote! {
-							panic!()
+						{
+							let hash = event.signature.hash();
+
+							let hash_bytes = hash.as_ref().iter().map(|b| {
+								syn::Lit::Int(*b as u64, syn::IntTy::U8)
+							});
+
+							let indexed_pats = event.indexed.iter()
+								.map(|&(ref pat, _)| pat);
+
+							let data_pats = event.data.iter()
+								.map(|&(ref pat, _)| pat);
+
+							quote! {
+								let topics = &[
+									[#(#hash_bytes),*].into(),
+									#(::pwasm_abi::eth::AsLog::as_log(&#indexed_pats)),*
+								];
+								let values: &[::pwasm_abi::eth::ValueType] = &[
+									#(#data_pats.into()),*
+								];
+								let payload = ::pwasm_abi::eth::encode_values(values);
+							}
 						}
 					)
 				]);

--- a/derive/src/items.rs
+++ b/derive/src/items.rs
@@ -135,6 +135,8 @@ impl quote::ToTokens for Item {
 									#(#data_pats.into()),*
 								];
 								let payload = ::pwasm_abi::eth::encode_values(values);
+
+								log(topics, &payload);
 							}
 						}
 					)

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -38,63 +38,6 @@ pub fn eth_abi(args: TokenStream, input: TokenStream) -> TokenStream {
 	generated.parse().expect("Failed to parse generated input")
 }
 
-fn ty_to_param_type(ty: &syn::Ty) -> abi::eth::ParamType {
-	match *ty {
-		syn::Ty::Path(None, ref path) => {
-			let last_path = path.segments.last().unwrap();
-			match last_path.ident.to_string().as_ref() {
-				"u32" => abi::eth::ParamType::U32,
-				"i32" => abi::eth::ParamType::I32,
-				"u64" => abi::eth::ParamType::U64,
-				"i64" => abi::eth::ParamType::I64,
-				"U256" => abi::eth::ParamType::U256,
-				"H256" => abi::eth::ParamType::H256,
-				"Address" => abi::eth::ParamType::Address,
-				"Vec" => {
-					match last_path.parameters {
-						syn::PathParameters::AngleBracketed(ref param_data) => {
-							let vec_arg = param_data.types.last().unwrap();
-							if let syn::Ty::Path(None, ref nested_path) = *vec_arg {
-								if "u8" == nested_path.segments.last().unwrap().ident.to_string() {
-									return abi::eth::ParamType::Bytes;
-								}
-							}
-							abi::eth::ParamType::Array(ty_to_param_type(vec_arg).into())
-						},
-						_ => panic!("Unsupported vec arguments"),
-					}
-				},
-				"String" => abi::eth::ParamType::String,
-				"bool" => abi::eth::ParamType::Bool,
-				ref val @ _ => panic!("Unable to handle param of type {}: not supported by abi", val)
-			}
-		},
-		ref val @ _ => panic!("Unable to handle param of type {:?}: not supported by abi", val),
-	}
-}
-
-fn parse_rust_signature(method_sig: &syn::MethodSig) -> abi::eth::Signature {
-	let mut params = Vec::new();
-
-	for fn_arg in method_sig.decl.inputs.iter() {
-		match *fn_arg {
-			syn::FnArg::Captured(_, ref ty) => {
-				params.push(ty_to_param_type(ty));
-			},
-			syn::FnArg::SelfValue(_) => { panic!("cannot use self by value"); },
-			_ => {},
-		}
-	}
-
-	abi::eth::Signature::new(
-		params,
-		match method_sig.decl.output {
-			syn::FunctionRetTy::Default => None,
-			syn::FunctionRetTy::Ty(ref ty) => Some(ty_to_param_type(ty)),
-		}
-	)
-}
-
 fn item_to_signature(item: &Item) -> Option<abi::eth::NamedSignature> {
 	match *item {
 		Item::Signature(ref ident, ref method_sig) => {
@@ -102,7 +45,7 @@ fn item_to_signature(item: &Item) -> Option<abi::eth::NamedSignature> {
 			Some(
 				abi::eth::NamedSignature::new(
 					name,
-					parse_rust_signature(method_sig),
+					utils::parse_rust_signature(method_sig),
 				)
 			)
 		},
@@ -236,11 +179,12 @@ fn impl_eth_dispatch(
 					}
 				))
 			},
-			Item::Event(ref ident, ref method_sig)  => {
+			Item::Event(ref event)  => {
 				Some(utils::produce_signature(
-					ident,
-					method_sig,
+					&event.name,
+					&event.method_sig,
 					quote!{
+						#![allow(unused_variables)]
 						panic!("cannot use event in client interface");
 					}
 				))

--- a/derive/src/utils.rs
+++ b/derive/src/utils.rs
@@ -1,0 +1,31 @@
+use {syn, quote};
+
+pub fn produce_signature<T: quote::ToTokens>(
+	ident: &syn::Ident,
+	method_sig: &syn::MethodSig,
+	t: T,
+) -> quote::Tokens
+{
+	let args = method_sig.decl.inputs.iter().filter_map(|arg| {
+		match *arg {
+			syn::FnArg::Captured(ref pat, ref ty) => Some(quote!{#pat: #ty}),
+			_ => None,
+		}
+	});
+	match method_sig.decl.output {
+		syn::FunctionRetTy::Ty(ref output) => {
+			quote!{
+				fn #ident(&mut self, #(#args),*) -> #output {
+					#t
+				}
+			}
+		},
+		syn::FunctionRetTy::Default => {
+			quote!{
+				fn #ident(&mut self, #(#args),*) {
+					#t
+				}
+			}
+		}
+	}
+}

--- a/derive/src/utils.rs
+++ b/derive/src/utils.rs
@@ -1,4 +1,32 @@
-use {syn, quote};
+use {syn, quote, abi};
+
+pub struct SignatureIterator<'a> {
+	method_sig: &'a syn::MethodSig,
+	position: usize,
+}
+
+impl<'a> Iterator for SignatureIterator<'a> {
+	type Item = (syn::Pat, syn::Ty);
+
+	fn next(&mut self) -> Option<Self::Item> {
+		while self.position < self.method_sig.decl.inputs.len() {
+			if let &syn::FnArg::Captured(ref pat, ref ty) = &self.method_sig.decl.inputs[self.position] {
+				self.position += 1;
+				return Some((pat.clone(), ty.clone()));
+			} else {
+				self.position += 1;
+			}
+		}
+		None
+	}
+}
+
+pub fn iter_signature(method_sig: &syn::MethodSig) -> SignatureIterator {
+	SignatureIterator {
+		method_sig: method_sig,
+		position: 0,
+	}
+}
 
 pub fn produce_signature<T: quote::ToTokens>(
 	ident: &syn::Ident,
@@ -28,4 +56,61 @@ pub fn produce_signature<T: quote::ToTokens>(
 			}
 		}
 	}
+}
+
+pub fn ty_to_param_type(ty: &syn::Ty) -> abi::eth::ParamType {
+	match *ty {
+		syn::Ty::Path(None, ref path) => {
+			let last_path = path.segments.last().unwrap();
+			match last_path.ident.to_string().as_ref() {
+				"u32" => abi::eth::ParamType::U32,
+				"i32" => abi::eth::ParamType::I32,
+				"u64" => abi::eth::ParamType::U64,
+				"i64" => abi::eth::ParamType::I64,
+				"U256" => abi::eth::ParamType::U256,
+				"H256" => abi::eth::ParamType::H256,
+				"Address" => abi::eth::ParamType::Address,
+				"Vec" => {
+					match last_path.parameters {
+						syn::PathParameters::AngleBracketed(ref param_data) => {
+							let vec_arg = param_data.types.last().unwrap();
+							if let syn::Ty::Path(None, ref nested_path) = *vec_arg {
+								if "u8" == nested_path.segments.last().unwrap().ident.to_string() {
+									return abi::eth::ParamType::Bytes;
+								}
+							}
+							abi::eth::ParamType::Array(ty_to_param_type(vec_arg).into())
+						},
+						_ => panic!("Unsupported vec arguments"),
+					}
+				},
+				"String" => abi::eth::ParamType::String,
+				"bool" => abi::eth::ParamType::Bool,
+				ref val @ _ => panic!("Unable to handle param of type {}: not supported by abi", val)
+			}
+		},
+		ref val @ _ => panic!("Unable to handle param of type {:?}: not supported by abi", val),
+	}
+}
+
+pub fn parse_rust_signature(method_sig: &syn::MethodSig) -> abi::eth::Signature {
+	let mut params = Vec::new();
+
+	for fn_arg in method_sig.decl.inputs.iter() {
+		match *fn_arg {
+			syn::FnArg::Captured(_, ref ty) => {
+				params.push(ty_to_param_type(ty));
+			},
+			syn::FnArg::SelfValue(_) => { panic!("cannot use self by value"); },
+			_ => {},
+		}
+	}
+
+	abi::eth::Signature::new(
+		params,
+		match method_sig.decl.output {
+			syn::FunctionRetTy::Default => None,
+			syn::FunctionRetTy::Ty(ref ty) => Some(ty_to_param_type(ty)),
+		}
+	)
 }

--- a/src/eth/log.rs
+++ b/src/eth/log.rs
@@ -1,0 +1,62 @@
+use byteorder::{BigEndian, ByteOrder};
+use parity_hash::H256;
+use bigint::U256;
+
+trait AsLog {
+    fn as_log(&self) -> H256;
+}
+
+impl AsLog for u32 {
+    fn as_log(&self) -> H256 {
+        let mut result = H256::zero();
+        BigEndian::write_u32(&mut result.as_mut()[28..32], *self);
+        result
+    }
+}
+
+impl AsLog for u64 {
+    fn as_log(&self) -> H256 {
+        let mut result = H256::zero();
+        BigEndian::write_u64(&mut result.as_mut()[24..32], *self);
+        result
+    }
+}
+
+impl AsLog for i64 {
+    fn as_log(&self) -> H256 {
+        let mut result = H256::zero();
+        BigEndian::write_i64(&mut result.as_mut()[24..32], *self);
+        result
+    }
+}
+
+impl AsLog for i32 {
+    fn as_log(&self) -> H256 {
+        let mut result = H256::zero();
+        BigEndian::write_i32(&mut result.as_mut()[28..32], *self);
+        result
+    }
+}
+
+
+impl AsLog for bool {
+    fn as_log(&self) -> H256 {
+        let mut result = H256::zero();
+        result.as_mut()[32] = if *self { 1 } else { 0 };
+        result
+    }
+}
+
+impl AsLog for U256 {
+    fn as_log(&self) -> H256 {
+        let mut result = H256::zero();
+        self.to_big_endian(result.as_mut());
+        result
+    }
+}
+
+impl AsLog for H256 {
+    fn as_log(&self) -> H256 {
+        self.clone()
+    }
+}

--- a/src/eth/log.rs
+++ b/src/eth/log.rs
@@ -2,7 +2,7 @@ use byteorder::{BigEndian, ByteOrder};
 use parity_hash::H256;
 use bigint::U256;
 
-trait AsLog {
+pub trait AsLog {
     fn as_log(&self) -> H256;
 }
 

--- a/src/eth/mod.rs
+++ b/src/eth/mod.rs
@@ -7,6 +7,7 @@ mod encode;
 mod decode;
 mod util;
 mod dispatch;
+mod log;
 
 pub use self::param_type::{ParamType, ArrayRef};
 pub use self::value_type::ValueType;

--- a/src/eth/mod.rs
+++ b/src/eth/mod.rs
@@ -14,3 +14,5 @@ pub use self::value_type::ValueType;
 pub use self::signature::Signature;
 pub use self::util::Error;
 pub use self::dispatch::{HashSignature, NamedSignature, Table};
+pub use self::log::AsLog;
+pub use self::encode::encode as encode_values;

--- a/src/eth/value_type.rs
+++ b/src/eth/value_type.rs
@@ -45,7 +45,6 @@ impl From<H256> for ValueType {
     }
 }
 
-
 impl From<ValueType> for u32 {
     fn from(val: ValueType) -> Self {
         match val {

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -27,7 +27,7 @@ extern crate bigint;
 use pwasm_abi_derive::eth_abi;
 
 use bigint::U256;
-use parity_hash::Address;
+use parity_hash::{H256, Address};
 
 #[eth_abi(Endpoint, Client)]
 pub trait TestContract {
@@ -72,6 +72,10 @@ thread_local!(pub static LAST_CALL: RefCell<Vec<u8>> = RefCell::new(Vec::new()))
 fn call(_address: &Address, _value: U256, input: &[u8], _result: &mut [u8]) -> Result<(), ()> {
 	LAST_CALL.with(|v| { *v.borrow_mut() = input.to_vec(); });
 	Ok(())
+}
+
+#[cfg(test)]
+fn log(_topics: &[H256], _data: &[u8]) {
 }
 
 #[test]

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -36,6 +36,9 @@ pub trait TestContract {
 	fn baz(&mut self, _p1: u32, _p2: bool);
 	fn boo(&mut self, _arg: u32) -> u32;
 	fn sam(&mut self, _p1: Vec<u8>, _p2: bool, _p3: Vec<U256>);
+
+	#[event]
+	fn baz_fired(&mut self, indexed_p1: u32, p2: u32);
 }
 
 const PAYLOAD_SAMPLE_1: &[u8] = &[
@@ -62,8 +65,10 @@ const PAYLOAD_SAMPLE_3: &[u8] = &[
 	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x45,
 ];
 
+#[cfg(test)]
 thread_local!(pub static LAST_CALL: RefCell<Vec<u8>> = RefCell::new(Vec::new()));
 
+#[cfg(test)]
 fn call(_address: &Address, _value: U256, input: &[u8], _result: &mut [u8]) -> Result<(), ()> {
 	LAST_CALL.with(|v| { *v.borrow_mut() = input.to_vec(); });
 	Ok(())


### PR DESCRIPTION
can be just

```rust
#[event]
fn baz_fired(indexed_p1: u32, p2: u32);
```

(implementation will be added automatically)