### PR TITLE
Fix padding test

### DIFF
--- a/src/eth/common.rs
+++ b/src/eth/common.rs
@@ -172,7 +172,7 @@ impl AbiType for i32 {
 		let slice = &stream.payload()[previous_position..stream.position()];
 
 		// only negative path here
-		if !slice[1..28].iter().all(|x| *x == 0xff) {
+		if !slice[0..28].iter().all(|x| *x == 0xff) {
 			return Err(Error::InvalidPadding);
 		}
 
@@ -206,7 +206,7 @@ impl AbiType for i64 {
 		let slice = &stream.payload()[previous_position..stream.position()];
 
 		// only negative path here
-		if !slice[1..24].iter().all(|x| *x == 0xff) {
+		if !slice[0..24].iter().all(|x| *x == 0xff) {
 			return Err(Error::InvalidPadding);
 		}
 

--- a/src/eth/mod.rs
+++ b/src/eth/mod.rs
@@ -15,7 +15,7 @@ pub use self::stream::Stream;
 pub use self::sink::Sink;
 
 /// Error for decoding rust types from stream
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum Error {
 	/// Invalid bool for provided input
 	InvalidBool,

--- a/src/eth/tests.rs
+++ b/src/eth/tests.rs
@@ -184,3 +184,19 @@ fn negative_i32_max() {
 	let value: i32 = stream.pop().expect("x failed to pop");
 	assert_eq!(value, x);
 }
+
+#[test]
+fn padding_test_i32() {
+	let mut sample = [0xff; 32];
+	sample[0] = 0x80;
+	let mut stream = ::eth::Stream::new(&sample);
+	assert_eq!(stream.pop::<i32>().unwrap_err(), Error::InvalidPadding);
+}
+
+#[test]
+fn padding_test_i64() {
+	let mut sample = [0xff; 32];
+	sample[0] = 0x80;
+	let mut stream = ::eth::Stream::new(&sample);
+	assert_eq!(stream.pop::<i64>().unwrap_err(), Error::InvalidPadding);
+}


### PR DESCRIPTION
The tests are checking only the first bit, not a whole byte.
So values like `0x80FFFF...` passed this check.