### PR TITLE
Fix for unexpected comma (syntax error) if contract trait have no methods but constructor

### DIFF
--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -277,7 +277,7 @@ fn impl_eth_dispatch(
 				let method_payload = &payload[4..];
 
 				match method_id {
-					#(#branches),*,
+					#(#branches,)*
 					_ => panic!("Invalid method signature"),
 				}
 			}

--- a/tests/src/erc20.rs
+++ b/tests/src/erc20.rs
@@ -4,6 +4,7 @@ use pwasm_abi::eth::EndpointInterface;
 
 mod contract {
 	#![allow(non_snake_case)]
+	#![allow(dead_code)]
 
 	use pwasm_abi_derive::eth_abi;
 	use parity_hash::Address;

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -180,17 +180,20 @@ fn dispatch_empty_abi() {
 	}
 
 	struct EmptyContractInstance {
+		pub called: bool
 	}
 
 	impl EmptyContract for EmptyContractInstance {
 		fn constructor(&mut self, _p1: bool) {
+			self.called = true;
 		}
 	}
 
-	let mut endpoint = EmptyEndpoint::new(EmptyContractInstance{});
+	let mut endpoint = EmptyEndpoint::new(EmptyContractInstance{called: false});
 	endpoint.dispatch_ctor(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01]);
+	assert!(endpoint.inner.called);
 }
 
 test_with_external!(

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -171,6 +171,28 @@ fn boo_dispatch() {
 	assert!(!endpoint.inner.called_wrong, "wrong method was invoked");
 }
 
+#[allow(dead_code)]
+#[test]
+fn dispatch_empty_abi() {
+	#[eth_abi(EmptyEndpoint, _EmptyClient)]
+	trait EmptyContract {
+		fn constructor(&mut self, _p: bool);
+	}
+
+	struct EmptyContractInstance {
+	}
+
+	impl EmptyContract for EmptyContractInstance {
+		fn constructor(&mut self, _p1: bool) {
+		}
+	}
+
+	let mut endpoint = EmptyEndpoint::new(EmptyContractInstance{});
+	endpoint.dispatch_ctor(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01]);
+}
+
 test_with_external!(
 	ExternalBuilder::new().build(),
 	baz_call {

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -180,20 +180,23 @@ fn dispatch_empty_abi() {
 	}
 
 	struct EmptyContractInstance {
-		pub called: bool
+		pub called: bool,
+		pub p: bool
 	}
 
 	impl EmptyContract for EmptyContractInstance {
-		fn constructor(&mut self, _p1: bool) {
+		fn constructor(&mut self, p1: bool) {
 			self.called = true;
+			self.p = p1;
 		}
 	}
 
-	let mut endpoint = EmptyEndpoint::new(EmptyContractInstance{called: false});
+	let mut endpoint = EmptyEndpoint::new(EmptyContractInstance{called: false, p: false});
 	endpoint.dispatch_ctor(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01]);
 	assert!(endpoint.inner.called);
+	assert!(endpoint.inner.p);
 }
 
 test_with_external!(


### PR DESCRIPTION
+ fix warnings