### PR TITLE
Change uint dependency to the one provided by ethereum-types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,8 @@ panic = "abort"
 [dependencies]
 pwasm-std = "0.10"
 
-[dependencies.uint]
-version = "0.3"
+[dependencies.ethereum-types]
+version = "0.4"
 default-features = false
 
 [dependencies.byteorder]
@@ -31,5 +31,5 @@ hex-literal = "0.1"
 
 [features]
 default = []
-std = ["uint/std", "pwasm-std/std"]
+std = ["ethereum-types/std", "pwasm-std/std"]
 strict = []

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -19,7 +19,7 @@ quote = "0.3"
 syn = { version = "0.11", features = ["full"] }
 tiny-keccak = { version = "1.4.2", default-features = false }
 byteorder = { version = "1.2.3", default-features = false }
-parity-hash = { version = "1.2.2", default-features = false }
+ethereum-types = { version = "0.4", default-features = false }
 serde = "1.0.70"
 serde_json = "1.0.24"
 serde_derive = "1.0.70"

--- a/derive/src/items.rs
+++ b/derive/src/items.rs
@@ -1,5 +1,7 @@
 use {quote, syn, utils};
 
+use ethereum_types::H256;
+
 pub struct Interface {
 	name: String,
 	constructor: Option<Signature>,
@@ -165,8 +167,8 @@ impl quote::ToTokens for Item {
 						name,
 						method_sig,
 						{
-							let keccak = utils::keccak(&event.canonical);
-							let hash_bytes = keccak.as_ref().iter().map(|b| {
+							let keccak: H256 = utils::keccak(&event.canonical);
+							let hash_bytes = (&keccak).iter().map(|b| {
 								syn::Lit::Int(*b as u64, syn::IntTy::U8)
 							});
 

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -8,7 +8,7 @@ extern crate syn;
 #[macro_use] extern crate quote;
 extern crate tiny_keccak;
 extern crate byteorder;
-extern crate parity_hash;
+extern crate ethereum_types;
 extern crate serde_json;
 #[macro_use] extern crate serde_derive;
 

--- a/derive/src/utils.rs
+++ b/derive/src/utils.rs
@@ -1,6 +1,6 @@
 use {syn, quote};
 use tiny_keccak::Keccak;
-use parity_hash::H256;
+use ethereum_types::H256;
 use byteorder::{BigEndian, ByteOrder};
 
 pub struct SignatureIterator<'a> {
@@ -145,6 +145,6 @@ pub fn keccak(s: &str) -> H256 {
 }
 
 pub fn hash(s: &str) -> u32 {
-	let keccak = keccak(s);
-	BigEndian::read_u32(&keccak.as_ref()[0..4])
+	let keccak: H256 = keccak(s);
+	BigEndian::read_u32(&keccak[0..4])
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 #![cfg_attr(feature="strict", deny(unused))]
 
 extern crate byteorder;
-extern crate uint;
+extern crate ethereum_types;
 extern crate pwasm_std;
 
 #[cfg(test)]
@@ -23,7 +23,7 @@ pub mod eth;
 pub mod types {
 	pub use pwasm_std::Vec;
 	pub use pwasm_std::hash::*;
-	pub use uint::U256;
+	pub use ethereum_types::U256;
 }
 
 mod lib {

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 authors = ["NikVolf <nikvolf@gmail.com>"]
 
 [dependencies]
-pwasm-std = "0.10"
+# pwasm-std = "0.10"
 pwasm-test = { git = "https://github.com/paritytech/pwasm-test", optional = true }
 pwasm-abi = { path = "..", default-features=false }
 pwasm-abi-derive = { path = "../derive" }
@@ -12,4 +12,4 @@ pwasm-ethereum = "0.6.3"
 
 [features]
 default = []
-test = ["pwasm-test", "pwasm-std/std", "pwasm-ethereum/std"]
+test = ["pwasm-test", "pwasm-std/std", "pwasm-ethereum/std", "pwasm-abi/std"]

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -4,12 +4,17 @@ version = "0.0.0"
 authors = ["NikVolf <nikvolf@gmail.com>"]
 
 [dependencies]
-# pwasm-std = "0.10"
 pwasm-test = { git = "https://github.com/paritytech/pwasm-test", optional = true }
 pwasm-abi = { path = "..", default-features=false }
 pwasm-abi-derive = { path = "../derive" }
-pwasm-ethereum = "0.7"
 
+[dependencies.pwasm-ethereum]
+# version = "0.7"
+git = "https://github.com/Robbepop/pwasm-ethereum"
+
+[dependencies.pwasm-std]
+# version = "0.10"
+git = "https://github.com/Robbepop/pwasm-std"
 
 [features]
 default = []

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -8,7 +8,8 @@ authors = ["NikVolf <nikvolf@gmail.com>"]
 pwasm-test = { git = "https://github.com/paritytech/pwasm-test", optional = true }
 pwasm-abi = { path = "..", default-features=false }
 pwasm-abi-derive = { path = "../derive" }
-pwasm-ethereum = "0.6.3"
+pwasm-ethereum = "0.7"
+
 
 [features]
 default = []


### PR DESCRIPTION
The ethereum-types uint allows for specific ethereum serialization and deserialization that is specific to ethereum. This is required by `fleetwood` that depends on `pwasm-abi` but requires ethereum specific (de)serialization features that the previous and deprecated dependency `bigint` (for `U256`) provided.