### PR TITLE
Fix for cannot find type `Vec` in this scope

### DIFF
--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -171,7 +171,7 @@ fn generate_eth_endpoint_wrapper(
 		mod #mod_name_ident {
 			extern crate pwasm_ethereum;
 			extern crate pwasm_abi;
-			use pwasm_abi::types::{H160, H256, U256, Address};
+			use pwasm_abi::types::{H160, H256, U256, Address, Vec};
 			use super::#name_ident_use;
 			#endpoint_toks
 		}
@@ -205,7 +205,7 @@ fn generate_eth_endpoint_and_client_wrapper(
 		mod #mod_name_ident {
 			extern crate pwasm_ethereum;
 			extern crate pwasm_abi;
-			use pwasm_abi::types::{H160, H256, U256, Address};
+			use pwasm_abi::types::{H160, H256, U256, Address, Vec};
 			use super::#name_ident_use;
 			#endpoint_toks
 			#client_toks


### PR DESCRIPTION
closes #79 